### PR TITLE
Fix incorrect escaping of characters

### DIFF
--- a/symfony2/yaml/misc.yml
+++ b/symfony2/yaml/misc.yml
@@ -10,10 +10,10 @@ questions:
     -
         question: 'What is the LoggerInterface correct namespace?'
         answers:
-            - {value: "Psr\LoggerInterface",                        correct: false}
-            - {value: "Psr\Log\LoggerInterface",                    correct: true}
-            - {value: "Symfony\Bridge\Monolog\LoggerInterface",     correct: false}
-            - {value: "Symfony\Bridge\Monolog\Log\LoggerInterface", correct: false}
+            - {value: "Psr\\LoggerInterface",                        correct: false}
+            - {value: "Psr\\Log\\LoggerInterface",                    correct: true}
+            - {value: "Symfony\\Bridge\\Monolog\\LoggerInterface",     correct: false}
+            - {value: "Symfony\\Bridge\\Monolog\\Log\\LoggerInterface", correct: false}
     -
         question: 'Using a dev environment, what is the correct cached file name of the dependency injection container?'
         answers:


### PR DESCRIPTION
It seems that the namespace is incorrectly escaped:

![image](https://cloud.githubusercontent.com/assets/238295/5800229/65350bca-9fdc-11e4-9e9f-26636e8389d5.png)

It's very hard to give the correct answer now ;)