### PR TITLE
Fix answer on console helper

### DIFF
--- a/symfony2/yaml/console.yml
+++ b/symfony2/yaml/console.yml
@@ -3,7 +3,7 @@ questions:
     -
         question: 'Which helper is not available in the Console component?'
         answers:
-            - {value: "QuestionHelper", correct: false}
+            - {value: "QuestionHelper", correct: true}
             - {value: "TableHelper",    correct: false}
             - {value: "FileHelper",     correct: true}
             - {value: "DialogHelper",   correct: false}


### PR DESCRIPTION
QuestionHelper does not exist in Symfony 2.3

http://symfony.com/doc/2.3/components/console/introduction.html#console-helpers