### PR TITLE
fixed wrong answer in Standardization

### DIFF
--- a/symfony2/yaml/standardization.yml
+++ b/symfony2/yaml/standardization.yml
@@ -5,7 +5,7 @@ questions:
         answers:
             - {value: "MyTestCommand.php",        correct: true}
             - {value: "CommandMyTest.php",        correct: false}
-            - {value: "MyTestConsoleCommand.php", correct: false}
+            - {value: "MyTestConsoleCmd.php",     correct: false}
             - {value: "MyTestCommandConsole.php", correct: false}
     -
         question: 'How to render properly template located in src/Acme/TestBundle/Resources/views/Question/Item/list.html.twig?'


### PR DESCRIPTION
As it ends with "Command" it is actually a valid name for a command even though the "Console" has no futher meaning here.
